### PR TITLE
Rework Renovate setup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
   ],
@@ -7,5 +8,21 @@
       "^requirements.txt$",
       "^requirements_saml.txt$"
     ]
-  }
+  },
+  "automerge": true,
+  "automergeType": "branch",
+  "major": {
+    "automerge": false
+  },
+  "masterIssue": true,
+  "prCreation": "not-pending",
+  "stabilityDays": 3,
+  "prNotPendingHours": 74,
+  "schedule": [
+    "before 9am",
+    "after 3pm on monday through thursday",
+    "after 3am on saturday",
+    "on sunday"
+  ],
+  "timezone": "Europe/Oslo"
 }


### PR DESCRIPTION
I praksis betyr dette at Renovate vil merge de aller fleste PR-ene vi får her, bare ikke de som enten feiler tester eller er major updates.

Jeg tipper dette vil føre til at vi brekker siden i blant, siden vi har litt lav testdekning. Men tenker det er greit, og at vi i så fall bare fikser det når det skjer, og gjerne ser om vi kan legge inn en enkel regresjonstest.

Jeg har satt slik at Renovate kun merger ting utenom kafétid og fredagspub, så vi reduserer muligheten for at feil introduseres akkurat da.